### PR TITLE
Passing variable to application by sysbuild test

### DIFF
--- a/samples/sysbuild/hello_world/CMakeLists.txt
+++ b/samples/sysbuild/hello_world/CMakeLists.txt
@@ -1,6 +1,9 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+message("In app CMakeLists.txt")
+message("APP_CONFIG: ${APP_CONFIG}")
+
 cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 

--- a/samples/sysbuild/hello_world/sysbuild.cmake
+++ b/samples/sysbuild/hello_world/sysbuild.cmake
@@ -1,6 +1,9 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+message("In sysbuild.cmake")
+message("APP_CONFIG: ${APP_CONFIG}")
+
 if("${SB_CONFIG_REMOTE_BOARD}" STREQUAL "")
   message(FATAL_ERROR "REMOTE_BOARD must be set to a valid board name")
 endif()

--- a/samples/sysbuild/hello_world/sysbuild/CMakeLists.txt
+++ b/samples/sysbuild/hello_world/sysbuild/CMakeLists.txt
@@ -1,0 +1,8 @@
+message("In sysbuild/CMakeLists.txt")
+message("APP_CONFIG: ${APP_CONFIG}")
+
+set(hello_world_APP_CONFIG ${APP_CONFIG} CACHE STRING "Application configuration selection")
+
+
+find_package(Sysbuild REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(sysbuild LANGUAGES)


### PR DESCRIPTION
Build without sysbuild:
west build -p -b nrf5340dk/nrf5340/cpuapp -- -DAPP_CONFIG="great_work"

Build with sysbuild:
west build --sysbuild -p -b nrf5340dk/nrf5340/cpuapp -- -DAPP_CONFIG="great_work" -DSB_CONF_FILE=sysbuild/nrf5340dk_nrf5340_cpunet.conf